### PR TITLE
Add Alt+P keyboard shortcut for play/pause

### DIFF
--- a/templates/transcribe.html
+++ b/templates/transcribe.html
@@ -146,6 +146,7 @@
         let statsNumPauseClicks = 0;
         let statsNumPlayClicks = 0;
         let statsStartTime = 0;
+        let altRightPressed = false;
 
 
         function formatTime(seconds) {
@@ -436,6 +437,33 @@
                     statsNumPauseClicks++;
                 }
             });
+            document.addEventListener('keydown', (event) => {
+    if (event.code === 'AltRight') {
+        altRightPressed = true;
+    }
+
+    if ((event.altKey || altRightPressed) && (
+        event.code === 'KeyP' ||
+        event.key === 'p' ||
+        event.key === 'P' ||
+        event.key === 'פ' ||
+        event.key === '.' ||
+        event.key === 'ף'
+    )) {
+        event.preventDefault();
+        if (player.playing) {
+            player.pause();
+        } else {
+            player.play();
+        }
+    }
+});
+
+document.addEventListener('keyup', (event) => {
+    if (event.code === 'AltRight') {
+        altRightPressed = false;
+    }
+});
         });
 
         audioPlayer.addEventListener('ended', function () {

--- a/templates/transcribe.html
+++ b/templates/transcribe.html
@@ -437,33 +437,34 @@
                     statsNumPauseClicks++;
                 }
             });
+
             document.addEventListener('keydown', (event) => {
-    if (event.code === 'AltRight') {
-        altRightPressed = true;
-    }
+                if (event.code === 'AltRight') {
+                    altRightPressed = true;
+                }
 
-    if ((event.altKey || altRightPressed) && (
-        event.code === 'KeyP' ||
-        event.key === 'p' ||
-        event.key === 'P' ||
-        event.key === 'פ' ||
-        event.key === '.' ||
-        event.key === 'ף'
-    )) {
-        event.preventDefault();
-        if (player.playing) {
-            player.pause();
-        } else {
-            player.play();
-        }
-    }
-});
+                if ((event.altKey || altRightPressed) && (
+                    event.code === 'KeyP' ||
+                    event.key === 'p' ||
+                    event.key === 'P' ||
+                    event.key === 'פ' ||
+                    event.key === '.' ||
+                    event.key === 'ף'
+                )) {
+                    event.preventDefault();
+                    if (player.playing) {
+                        player.pause();
+                    } else {
+                        player.play();
+                    }
+                }
+            });
 
-document.addEventListener('keyup', (event) => {
-    if (event.code === 'AltRight') {
-        altRightPressed = false;
-    }
-});
+            document.addEventListener('keyup', (event) => {
+                if (event.code === 'AltRight') {
+                    altRightPressed = false;
+                }
+            });
         });
 
         audioPlayer.addEventListener('ended', function () {


### PR DESCRIPTION
Adds keyboard shortcut functionality to play/pause the audio player using Alt+P.

- Works with both left and right Alt keys
- Compatible with both Hebrew and English keyboard layouts
- Works with either side of the keyboard