### PR TITLE
Audio player: Improved controls

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -460,3 +460,44 @@ button:hover {
     width: 1.5em;
     height: 1.5em;
 }
+
+/* Plyr Styles - a lot of '!important' in order to override Plyr defaults*/
+.plyr__controls {
+    display: grid !important;
+    gap: 8px !important;
+    padding: 8px !important;
+}
+
+/* Progress and time in first row, full width */
+.plyr__progress__container, .plyr__time {
+    grid-row: 1 !important;
+}
+
+.plyr__time {
+    width: 32px !important; /* Add width so that adding a '-' does not break the layout */
+}
+
+.plyr__progress__container {
+    margin-right: 8px !important;
+    grid-column: span 4 !important;
+    justify-self: stretch !important;
+}
+
+.plyr__progress__buffer,
+.plyr__progress {
+    width: 100% !important;
+
+    input[type="range"] {
+        width: 100% !important;
+    }
+}
+
+/* All other controls are in second row */
+.plyr__control,
+[data-plyr="mute"],
+.plyr__volume,
+[data-plyr="speed"],
+.plyr__menu {
+    grid-row: 2 !important;
+    width: fit-content;
+}

--- a/templates/transcribe.html
+++ b/templates/transcribe.html
@@ -598,11 +598,12 @@
         document.addEventListener('DOMContentLoaded', function () {
             // Initialize Plyr.js
             player = new Plyr(audioPlayer, {
-                controls: ['play', 'progress', 'current-time', 'mute', 'settings'],
+                controls:  ['current-time', 'progress', 'play', 'rewind', 'fast-forward', 'mute', 'volume', 'settings'],
                 speed: {
                     selected: 1,
                     options: [0.5, 1],
                 },
+                seekTime: 1,
             });
 
             player.on('play', function () {


### PR DESCRIPTION
Attempt to solve issue #14.

Add the following controls:
- Volume control.
- Fast forward / rewind 1 second (I chose 1 second for consistancy, since this is what is provided in the current keyboard shortcuts + many audio clips are only 3-4 seconds long, so jumping 2-3 seconds is a lot).

Adding these controls also made the player too with for mobile screen, which is now resolved by making the player's UI separated into 2 rows.

Desktop:
![image](https://github.com/user-attachments/assets/8c40db8c-4178-4a43-aa72-664c2d4310bd)

Mobile:
![image](https://github.com/user-attachments/assets/41691732-9df9-4fe0-85e5-5683d55384bb)
